### PR TITLE
fix(webhook): 修复多行正文导致 JSON 模板失效

### DIFF
--- a/app/notify.py
+++ b/app/notify.py
@@ -56,6 +56,25 @@ def _parse_headers(headers_text: str) -> dict[str, str]:
     return out
 
 
+def _render_template_value(value, title: str, content: str):
+    """Render placeholders after JSON parsing so multiline text stays valid JSON."""
+    if isinstance(value, str):
+        return value.replace("${title}", title).replace("${content}", content)
+    if isinstance(value, list):
+        return [_render_template_value(item, title, content) for item in value]
+    if isinstance(value, dict):
+        return {key: _render_template_value(item, title, content) for key, item in value.items()}
+    return value
+
+
+def _render_body_template(body_tpl: str, title: str, content: str):
+    try:
+        template_data = json.loads(body_tpl)
+    except (TypeError, json.JSONDecodeError):
+        return body_tpl.replace("${title}", title).replace("${content}", content)
+    return _render_template_value(template_data, title, content)
+
+
 def send_custom_webhook(
     webhook_url: str,
     content: str,
@@ -84,11 +103,7 @@ def send_custom_webhook(
 
     body_tpl = get_setting("custom_webhook_body", "") or ""
     if body_tpl:
-        rendered = body_tpl.replace("${title}", title_str).replace("${content}", content_str)
-        try:
-            body_data = json.loads(rendered)
-        except Exception:
-            body_data = rendered
+        body_data = _render_body_template(body_tpl, title_str, content_str)
     else:
         body_data = payload
 


### PR DESCRIPTION
## 问题

自定义 Webhook 当前会先替换 `${title}` 和 `${content}`，再解析 JSON 模板。当正文包含换行、双引号等需要 JSON 转义的字符时，替换后的 JSON 会解析失败，并以原始字符串发送。飞书等要求合法 JSON 的 Webhook 会因此拒绝请求。

## 修改

- 先将 Webhook body 模板解析为 JSON，再递归替换字符串字段中的占位符
- 由 `requests` 的 `json=` 参数负责最终序列化，正确处理换行和引号
- 保留非 JSON 纯文本模板原有的替换行为

## 验证

```bash
python -m py_compile app/notify.py
```
